### PR TITLE
日次チャットログ出力機能

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -17,8 +17,14 @@ const config = {
   channels: {
     evaluationResultChannelId: process.env.EVALUATION_RESULT_CHANNEL_ID,
     summaryNotificationChannelId: process.env.SUMMARY_NOTIFICATION_CHANNEL_ID,
-    excludedChannelIds: process.env.EXCLUDED_CHANNEL_IDS ? 
+    excludedChannelIds: process.env.EXCLUDED_CHANNEL_IDS ?
       process.env.EXCLUDED_CHANNEL_IDS.split(',').map(id => id.trim()) : [],
+  },
+  logsExport: {
+    sourceChannelIds: process.env.LOG_SOURCE_CHANNEL_IDS
+      ? process.env.LOG_SOURCE_CHANNEL_IDS.split(',').map(id => id.trim()).filter(Boolean)
+      : [],
+    exportChannelId: process.env.LOG_EXPORT_CHANNEL_ID || null,
   },
   cron: {
     schedule: process.env.CRON_SCHEDULE || '0 18 * * *',

--- a/src/services/logExportService.js
+++ b/src/services/logExportService.js
@@ -11,21 +11,23 @@ class LogExportService {
    * @returns {{ startUtc: Date, endUtc: Date, jstDateLabel: string }}
    */
   getPreviousDayJstRange() {
+    const offsetMs = 9 * 60 * 60 * 1000; // JST(+9h)
     const now = new Date();
-    const jstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+    const jstNow = new Date(now.getTime() + offsetMs);
     const y = jstNow.getUTCFullYear();
     const m = jstNow.getUTCMonth();
     const d = jstNow.getUTCDate();
 
-    // 00:00 JST は UTC の 15:00 前日、23:59:59.999 JST は UTC の 14:59:59.999 当日
-    const startUtc = new Date(Date.UTC(y, m, d - 1, 15, 0, 0, 0));
-    const endUtc = new Date(Date.UTC(y, m, d, 14, 59, 59, 999));
+    // 前日JST 00:00 -> UTC (前々日 15:00)
+    const startUtc = new Date(Date.UTC(y, m, d - 2, 15, 0, 0, 0));
+    // 前日JST 23:59:59.999 -> UTC (前日 14:59:59.999)
+    const endUtc = new Date(Date.UTC(y, m, d - 1, 14, 59, 59, 999));
 
-    // ラベル用（JST基準の日付 YYYYMMDD）
-    const jstPrev = new Date(Date.UTC(y, m, d - 1, 0, 0, 0, 0));
-    const yyyy = jstPrev.getUTCFullYear();
-    const mm = String(jstPrev.getUTCMonth() + 1).padStart(2, '0');
-    const dd = String(jstPrev.getUTCDate()).padStart(2, '0');
+    // ラベルは前日JSTの日付を使用（startUtcに+9hしてYYYYMMDDを作成）
+    const jstLabelDate = new Date(startUtc.getTime() + offsetMs);
+    const yyyy = jstLabelDate.getUTCFullYear();
+    const mm = String(jstLabelDate.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(jstLabelDate.getUTCDate()).padStart(2, '0');
     const jstDateLabel = `${yyyy}${mm}${dd}`;
 
     return { startUtc, endUtc, jstDateLabel };

--- a/src/services/logExportService.js
+++ b/src/services/logExportService.js
@@ -1,0 +1,246 @@
+const { AttachmentBuilder } = require('discord.js');
+const path = require('path');
+const logger = require('../utils/logger');
+const config = require('../config');
+const messageService = require('./messageService');
+
+class LogExportService {
+  constructor() { }
+
+  /**
+   * 前日(JST) 00:00:00.000 〜 23:59:59.999 のUTC範囲を取得
+   * @returns {{ startUtc: Date, endUtc: Date, jstDateLabel: string }}
+   */
+  getPreviousDayJstRange() {
+    const now = new Date();
+    const jstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+    const y = jstNow.getUTCFullYear();
+    const m = jstNow.getUTCMonth();
+    const d = jstNow.getUTCDate();
+
+    // 00:00 JST は UTC の 15:00 前日、23:59:59.999 JST は UTC の 14:59:59.999 当日
+    const startUtc = new Date(Date.UTC(y, m, d - 1, 15, 0, 0, 0));
+    const endUtc = new Date(Date.UTC(y, m, d, 14, 59, 59, 999));
+
+    // ラベル用（JST基準の日付 YYYYMMDD）
+    const jstPrev = new Date(Date.UTC(y, m, d - 1, 0, 0, 0, 0));
+    const yyyy = jstPrev.getUTCFullYear();
+    const mm = String(jstPrev.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(jstPrev.getUTCDate()).padStart(2, '0');
+    const jstDateLabel = `${yyyy}${mm}${dd}`;
+
+    return { startUtc, endUtc, jstDateLabel };
+  }
+
+  /**
+   * JSTの日時文字列に整形
+   * @param {Date} date
+   * @returns {string}
+   */
+  formatJst(date) {
+    return new Date(date).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo', hour12: false });
+  }
+
+  /**
+   * CSV行用に値をエスケープ
+   * @param {string|number|boolean|null|undefined} value
+   * @returns {string}
+   */
+  csvEscape(value) {
+    if (value === null || value === undefined) return '""';
+    let str = String(value);
+    // 2重引用符のエスケープ
+    str = str.replace(/"/g, '""');
+    return `"${str}"`;
+  }
+
+  /**
+   * スレッド（アクティブ/アーカイブ）を取得
+   * @param {import('discord.js').TextChannel} channel
+   * @returns {Promise<Array<import('discord.js').ThreadChannel>>}
+   */
+  async fetchAllThreads(channel) {
+    const threads = [];
+    try {
+      const active = await channel.threads.fetchActive();
+      if (active && active.threads) {
+        active.threads.forEach(t => threads.push(t));
+      }
+    } catch (e) {
+      logger.warn(`Failed to fetch active threads for #${channel.name}:`, e.message || e);
+    }
+    try {
+      // 公開アーカイブ
+      const archivedPublic = await channel.threads.fetchArchived({ type: 'public' });
+      if (archivedPublic && archivedPublic.threads) {
+        archivedPublic.threads.forEach(t => threads.push(t));
+      }
+    } catch (e) {
+      logger.warn(`Failed to fetch archived public threads for #${channel.name}:`, e.message || e);
+    }
+    return threads;
+  }
+
+  /**
+   * 指定チャンネル（および配下スレッド）から期間内のメッセージを収集
+   * @param {import('discord.js').Client} client
+   * @param {string} channelId
+   * @param {Date} startUtc
+   * @param {Date} endUtc
+   * @returns {Promise<{ channelName: string, rows: string[] }>} rows はヘッダ除くデータ行
+   */
+  async collectChannelLogs(client, channelId, startUtc, endUtc) {
+    const channel = await client.channels.fetch(channelId).catch(() => null);
+    if (!channel) {
+      logger.warn(`Source channel not found: ${channelId}`);
+      return { channelName: `channel_${channelId}`, rows: [] };
+    }
+
+    // Text系のみ対象
+    if (!('messages' in channel)) {
+      logger.warn(`Channel is not text-based: ${channelId}`);
+      return { channelName: channel.name || `channel_${channelId}`, rows: [] };
+    }
+
+    const header = [
+      'timestamp_jst',
+      'message_id',
+      'channel_id',
+      'channel_name',
+      'author_id',
+      'author_name',
+      'content',
+      'mentions_user_ids',
+      'attachments_count',
+      'attachments_urls',
+      'is_reply',
+      'reply_to_message_id',
+    ].map(h => this.csvEscape(h)).join(',');
+
+    const rows = [header];
+
+    // 親チャンネルのメッセージ
+    const channelMessages = await messageService.fetchChannelMessages(channel, startUtc, endUtc);
+    for (const msg of channelMessages) {
+      rows.push(this.buildCsvRow(msg, channel.id, channel.name));
+    }
+
+    // スレッドも対象
+    const threads = await this.fetchAllThreads(channel);
+    for (const thread of threads) {
+      const threadMessages = await messageService.fetchChannelMessages(thread, startUtc, endUtc);
+      for (const msg of threadMessages) {
+        // channel_id / channel_name はスレッドを指す
+        rows.push(this.buildCsvRow(msg, thread.id, thread.name));
+      }
+    }
+
+    return { channelName: channel.name || `channel_${channelId}`, rows };
+  }
+
+  /**
+   * 1メッセージをCSV行に整形
+   * @param {import('discord.js').Message} msg
+   * @param {string} outChannelId
+   * @param {string} outChannelName
+   * @returns {string}
+   */
+  buildCsvRow(msg, outChannelId, outChannelName) {
+    const timestampJst = this.formatJst(new Date(msg.createdTimestamp));
+    const mentions = Array.from(msg.mentions?.users?.keys?.() || []);
+    const attachments = Array.from(msg.attachments?.values?.() || []);
+    const attachmentUrls = attachments.map(a => a.url).join(';');
+    const isReply = !!msg.reference;
+    const replyTo = msg.reference?.messageId || '';
+
+    const columns = [
+      timestampJst,
+      msg.id,
+      outChannelId,
+      outChannelName || '',
+      msg.author?.id || '',
+      msg.author?.username || '',
+      msg.content || '',
+      mentions.join('|'),
+      attachments.length,
+      attachmentUrls,
+      isReply,
+      replyTo,
+    ];
+
+    return columns.map(v => this.csvEscape(v)).join(',');
+  }
+
+  /**
+   * 1つのCSV添付を作成
+   * @param {string[]} rows
+   * @param {string} fileName
+   * @returns {AttachmentBuilder}
+   */
+  buildSingleAttachment(rows, fileName) {
+    const csv = rows.join('\n');
+    const buf = Buffer.from(csv, 'utf-8');
+    return new AttachmentBuilder(buf, { name: `${fileName}.csv` });
+  }
+
+  /**
+   * 前日分のメッセージを収集してCSV化し、送信先に投稿
+   * @param {import('discord.js').Client} client
+   */
+  async exportPreviousDayAndSend(client) {
+    try {
+      const { startUtc, endUtc, jstDateLabel } = this.getPreviousDayJstRange();
+
+      if (!config.logsExport.exportChannelId) {
+        logger.warn('LOG_EXPORT_CHANNEL_ID is not configured');
+        return;
+      }
+      if (!config.logsExport.sourceChannelIds || config.logsExport.sourceChannelIds.length === 0) {
+        logger.warn('LOG_SOURCE_CHANNEL_IDS is not configured');
+        return;
+      }
+
+      const exportChannel = await client.channels.fetch(config.logsExport.exportChannelId).catch(() => null);
+      if (!exportChannel) {
+        logger.warn(`Export channel not found: ${config.logsExport.exportChannelId}`);
+        return;
+      }
+
+      let totalCount = 0;
+      const allAttachments = [];
+      const detailLines = [];
+
+      for (const sourceId of config.logsExport.sourceChannelIds) {
+        const { channelName, rows } = await this.collectChannelLogs(client, sourceId, startUtc, endUtc);
+        const count = Math.max(0, rows.length - 1); // ヘッダ除く
+        totalCount += count;
+        detailLines.push(`• #${channelName || sourceId}: ${count}件`);
+
+        const safeName = (channelName || `channel_${sourceId}`).replace(/[^a-zA-Z0-9-_]/g, '_');
+        const fileName = `messages_${safeName}_${jstDateLabel}`;
+        const attachment = this.buildSingleAttachment(rows, fileName);
+        allAttachments.push(attachment);
+      }
+
+      const headerText = `【日次チャットログ収集レポート】 \n` +
+        `[期間]: ${this.formatJst(startUtc)} 〜 ${this.formatJst(endUtc)}\n` +
+        `[件数]: ${totalCount}件\n [対象チャンネル]:\n` +
+        (detailLines.length ? detailLines.join('\n') : '');
+
+      if (allAttachments.length === 0) {
+        await exportChannel.send({ content: headerText + '\n\n対象期間のメッセージはありませんでした。' });
+        logger.info('No messages found for export. Sent notification.');
+        return;
+      }
+
+      await exportChannel.send({ content: headerText, files: allAttachments });
+      logger.info(`Exported ${allAttachments.length} CSV file(s) for ${jstDateLabel}`);
+    } catch (error) {
+      logger.error('Error exporting daily logs:', error);
+    }
+  }
+}
+
+module.exports = new LogExportService();
+
+

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1,5 +1,6 @@
 const cron = require('node-cron');
 const evaluationService = require('./evaluationService');
+const logExportService = require('./logExportService');
 const config = require('../config');
 const logger = require('../utils/logger');
 
@@ -7,6 +8,7 @@ class SchedulerService {
   constructor() {
     this.client = null;
     this.scheduledTask = null;
+    this.logsTask = null;
   }
 
   /**
@@ -16,6 +18,7 @@ class SchedulerService {
   initialize(client) {
     this.client = client;
     this.setupScheduledEvaluation();
+    this.setupScheduledLogExport();
     logger.info(`Scheduler initialized with cron pattern: ${config.cron.schedule}`);
   }
 
@@ -41,6 +44,28 @@ class SchedulerService {
   }
 
   /**
+   * Setup scheduled daily log export at 18:00 JST
+   */
+  setupScheduledLogExport() {
+    // Cancel existing task if any
+    if (this.logsTask) {
+      this.logsTask.stop();
+    }
+
+    // Schedule daily log export at 18:00 JST
+    const cronPattern = '35 12 * * *';
+    this.logsTask = cron.schedule(cronPattern, async () => {
+      logger.info('Starting scheduled daily log export...');
+      await this.runDailyLogExport();
+    }, {
+      scheduled: true,
+      timezone: 'Asia/Tokyo'
+    });
+
+    logger.info('Daily log export scheduled at 18:00 JST');
+  }
+
+  /**
    * Run daily evaluation for all guilds
    */
   async runDailyEvaluation() {
@@ -53,16 +78,16 @@ class SchedulerService {
       for (const guild of this.client.guilds.cache.values()) {
         try {
           logger.info(`Running scheduled evaluation for guild: ${guild.name}`);
-          
+
           // Run evaluation
           const results = await evaluationService.evaluateGuild(guild, startDate, endDate);
-          
+
           // Post results to notification channel
           await this.postEvaluationNotification(guild, results);
-          
+
           // Post detailed results to result channel
           await this.postDetailedResults(guild, results);
-          
+
         } catch (error) {
           logger.error(`Error evaluating guild ${guild.name}:`, error);
         }
@@ -108,7 +133,7 @@ class SchedulerService {
             },
             {
               name: 'トップ貢献者',
-              value: results.summary.statistics.topContributors.length > 0 
+              value: results.summary.statistics.topContributors.length > 0
                 ? `<@${results.summary.statistics.topContributors[0].userId}> (${results.summary.statistics.topContributors[0].totalScore}点)`
                 : 'なし',
               inline: true,
@@ -197,7 +222,7 @@ class SchedulerService {
         for (const evaluation of topEvaluations) {
           const topParticipant = Object.entries(evaluation.evaluation.participants)
             .sort(([, a], [, b]) => b.score - a.score)[0];
-          
+
           if (topParticipant) {
             notableText += `• <@${topParticipant[0]}>: ${topParticipant[1].score}点\n`;
             if (evaluation.evaluation.summary) {
@@ -205,7 +230,7 @@ class SchedulerService {
             }
           }
         }
-        
+
         await channel.send(notableText.substring(0, 2000));
       }
 
@@ -223,6 +248,10 @@ class SchedulerService {
       this.scheduledTask.stop();
       logger.info('Scheduler stopped');
     }
+    if (this.logsTask) {
+      this.logsTask.stop();
+      logger.info('Log export scheduler stopped');
+    }
   }
 
   /**
@@ -231,6 +260,17 @@ class SchedulerService {
   async triggerManualEvaluation() {
     logger.info('Manual evaluation triggered');
     await this.runDailyEvaluation();
+  }
+
+  /**
+   * Run daily log export job
+   */
+  async runDailyLogExport() {
+    try {
+      await logExportService.exportPreviousDayAndSend(this.client);
+    } catch (error) {
+      logger.error('Error in daily log export:', error);
+    }
   }
 }
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -53,7 +53,7 @@ class SchedulerService {
     }
 
     // Schedule daily log export at 18:00 JST
-    const cronPattern = '35 12 * * *';
+    const cronPattern = '0 18 * * *';
     this.logsTask = cron.schedule(cronPattern, async () => {
       logger.info('Starting scheduled daily log export...');
       await this.runDailyLogExport();

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -53,8 +53,7 @@ class SchedulerService {
     }
 
     // Schedule daily log export at 18:00 JST
-    const cronPattern = '0 18 * * *';
-    this.logsTask = cron.schedule(cronPattern, async () => {
+    this.logsTask = cron.schedule(config.cron.schedule, async () => {
       logger.info('Starting scheduled daily log export...');
       await this.runDailyLogExport();
     }, {


### PR DESCRIPTION
## やったこと
- DiscordのAPIから過去24時間のメッセージを取得
- CSVファイルに変換し、指定したチャンネルにファイル添付したメッセージを送信

## 備考
- スケジュールは18時にしています
  - evaluateの時間とずらす等の対応も可能
- 集計期間は前日の0:00-23:59にしています
  - こちらも要件に合わせて変更可能
- チャンネルごとにファイルを分けて出力しています
  - まとめることも可能
  - botの添付ファイルサイズ制限が(おそらく)8MB
    - 1ファイルのcsvに200文字のメッセージ1万件程度は保存可能と試算
- 必要に応じて追加の情報(メッセージに対するリアクション等)もログに含めることが(おそらく)可能
- APIのレート制限は1秒あたり最大50件(ソース: https://discord.com/developers/docs/topics/rate-limits#rate-limits)
- メッセージ投稿時に逐一メッセージを取得→DBインサート→日次でDBから期間内のメッセージ全件取得→CSV出力のパターンも考えられる

## 出力例

```
"timestamp_jst","message_id","channel_id","channel_name","thread_id","thread_name","author_id","author_name","content","mentions_user_ids","attachments_count","attachments_urls","is_reply","reply_to_message_id"
"2025/9/2 16:44:26","1412342394808041492","1400751107206287411","times_aoyagi","","","710388387726753852","0xuyz","<@825021748957151242> 今日、作ってもらってるBotについて日産自動車さんのコミュニティにも提案してきた！
その結果いくつか要望をいただいており、その内容を↓にまとめてある！
https://www.notion.so/unyte/262c9aa9564a805ba5aacb5465355dd0?source=copy_link

これを作っていく作業を一緒にやりたく、明日また共有させて！","825021748957151242","0","","false",""
```